### PR TITLE
feat: adding apis to trigger custom dag runs and update schedules

### DIFF
--- a/src/dag_templates/base.py
+++ b/src/dag_templates/base.py
@@ -17,6 +17,8 @@ class BaseDagTemplate(object):
             'pool', 'default_pool') or 'default_pool'
         if 'start_date' in options:
             default_args['start_date'] = options['start_date']
+        if schedule_interval == "":
+            schedule_interval = None
         dag = DAG(
             dag_id,
             default_args=default_args,

--- a/src/dag_templates/fields.py
+++ b/src/dag_templates/fields.py
@@ -74,7 +74,7 @@ field_dag_id = StringField(
 
 field_schedule_interval = StringField(
     'Cron Schedule', validators=(
-        validators.required(), CronExpression()),
+        validators.optional(), CronExpression()),
     description=f'Specify the schedule interval in standard crontab format (https://crontab.guru/) or use one of the presets ({", ".join(cron_presets.keys())})'
 )
 

--- a/src/loader.py
+++ b/src/loader.py
@@ -104,8 +104,9 @@ class TemplateLoader(LoggingMixin):
                 "failed to load DAGs (probably since dagen tables are not loaded)", exc_info=e)
         for dbDag in dbDags:
             options = dbDag.live_version.dag_options
+            schedule_interval = dbDag.live_version.schedule_interval
             options = dict(dag_id=dbDag.dag_id,
-                           schedule_interval=dbDag.live_version.schedule_interval,
+                           schedule_interval=schedule_interval,
                            category=dbDag.category,
                            **options)
             try:

--- a/src/www/api_views.py
+++ b/src/www/api_views.py
@@ -7,7 +7,13 @@ except ImportError:
     from airflow.www.app import csrf
 from flask import (Blueprint, current_app, flash, g, jsonify, make_response,
                    redirect, request, url_for)
-
+from functools import wraps
+from airflow.api.common.experimental.trigger_dag import trigger_dag
+from airflow.configuration import conf
+from airflow.utils.session import create_session
+from croniter import croniter
+from datetime import datetime, timezone
+from dagen.models import DagenDag, DagenDagVersion
 from dagen.query import DagenDagQueryset, DagenDagVersionQueryset
 from dagen.www.utils import login_required
 from flask_appbuilder import expose, has_access
@@ -18,6 +24,8 @@ dagen_rest_bp = Blueprint('DagenRestView', __name__, url_prefix='/dagen/api')
 
 log = logging.root.getChild(f'{__name__}.{"DagenRestView"}')
 
+EXTERNAL_SCHEDULER_USER_ID = int(conf.get("ergo", "external_scheduler_user_id"))
+API_KEY = conf.get("ergo", "api_key")
 
 @csrf.exempt
 @dagen_rest_bp.route('/dags/approve/all', methods=('POST',))
@@ -76,4 +84,235 @@ def create_dag_json():
             return jsonify({"error": "Validation failed", "errors": form.errors}), 400
 
     except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+def require_api_key(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        key = request.headers.get("X-API-Key")
+        if key != API_KEY:
+            return jsonify({"error": "Unauthorized"}), 403
+        return f(*args, **kwargs)
+    return decorated
+
+#
+@csrf.exempt
+@dagen_rest_bp.route("/dags/run", methods=["POST"])
+@require_api_key
+def trigger_dag_run():
+    """
+    Trigger a manual DAG run with a specific execution datetime and optional configuration.
+
+    Expects a JSON payload:
+        - dag_id (str): Required. ID of the DAG to trigger.
+        - execution_date_time (str): Required. ISO 8601 datetime string with timezone (e.g., '2025-06-23T10:30:00+00:00').
+        - conf (dict): Optional. Configuration dictionary passed to the DAG.
+
+    Returns:
+        Response 200: DAG successfully triggered, returns run_id and execution_date_time.
+        Response 400: Missing or invalid parameters.
+        Response 500: Internal error while triggering DAG.
+    """
+    try:
+        data = request.get_json(force=True)
+
+        dag_id = data.get("dag_id")
+        execution_date_time_str = data.get("execution_date_time")
+        conf = data.get("conf", {})
+
+        if not dag_id:
+            return jsonify({"error": "Missing 'dag_id' in request body"}), 400
+
+        if not execution_date_time_str:
+            return jsonify({"error": "Missing 'execution_date_time' in request body"}), 400
+
+        try:
+            exec_date = datetime.fromisoformat(execution_date_time_str)
+        except ValueError:
+            return jsonify({"error": "Invalid 'execution_date_time' format, must be ISO 8601"}), 400
+
+        run_id = f"manual__{exec_date.isoformat()}"
+
+        dag_run = trigger_dag(
+            dag_id=dag_id,
+            run_id=run_id,
+            execution_date=exec_date,
+            conf=conf,
+        )
+
+        return jsonify({
+            "message": f"DAG '{dag_id}' triggered successfully",
+            "run_id": dag_run.run_id,
+            "execution_date_time": exec_date.isoformat()
+        }), 200
+
+    except Exception as e:
+        log.exception("Failed to trigger DAG")
+        return jsonify({"error": str(e)}), 500
+
+@dagen_rest_bp.route("/dags/schedule/update", methods=["PATCH"])
+@csrf.exempt
+@require_api_key
+def update_dag_schedule():
+    """
+    Update the schedule interval of a DAG by creating a new DAG version.
+
+    Expects a JSON payload:
+        - dag_id (str): Required. ID of the DAG to update.
+        - schedule_interval (str): Required. New cron expression (validated using croniter).
+
+    Returns:
+        Response 200: DAG schedule updated, returns the new version number.
+        Response 400: Missing or invalid parameters (e.g., invalid cron).
+        Response 404: DAG or DAG version not found.
+        Response 500: Internal error while updating the schedule.
+    """
+    try:
+        data = request.get_json(force=True)
+        dag_id = data.get("dag_id")
+        new_schedule = data.get("schedule_interval")
+
+        if not dag_id or not new_schedule:
+            return jsonify({"error": "Missing 'dag_id' or 'schedule_interval'"}), 400
+
+        if not croniter.is_valid(new_schedule):
+            return jsonify({"error": "Invalid 'schedule_interval'. Must be a valid cron expression."}), 400
+
+        with create_session() as session:
+            dag_obj = session.query(DagenDag).filter(DagenDag.dag_id == dag_id).first()
+            if not dag_obj:
+                return jsonify({"error": f"DAG '{dag_id}' not found"}), 404
+
+            latest_version = (
+                session.query(DagenDagVersion)
+                .filter(DagenDagVersion.dag_id == dag_id)
+                .order_by(DagenDagVersion.version.desc())
+                .first()
+            )
+            if not latest_version:
+                return jsonify({"error": f"No version found for DAG '{dag_id}'"}), 404
+
+            # Create a new version by copying values
+            new_version_number = latest_version.version + 1
+            new_version = DagenDagVersion(
+                dag_id=dag_id,
+                schedule_interval=new_schedule,
+                creator=EXTERNAL_SCHEDULER_USER_ID
+            )
+            new_version.set_options(latest_version.dag_options)
+            new_version.version = new_version_number
+            new_version.approver_id = EXTERNAL_SCHEDULER_USER_ID
+            new_version.approved_at = datetime.now(timezone.utc)
+
+
+            session.add(new_version)
+
+            dag_obj._live_version = new_version_number
+            dag_obj.updated_at = datetime.now(timezone.utc)
+
+            session.commit()
+
+        refresh_dagbag(dag_id=dag_id)
+        return jsonify({
+            "message": f"Schedule for DAG '{dag_id}' updated to '{new_schedule}', version {new_version_number}"
+        }), 200
+
+    except Exception as e:
+        log.exception("Failed to update DAG schedule")
+        return jsonify({"error": str(e)}), 500
+
+@csrf.exempt
+@dagen_rest_bp.route("/dags/schedule/revert/latest", methods=["POST"])
+@require_api_key
+def revert_latest_external_schedule_override():
+    """
+    Revert the most recent DAG version created by the external scheduler.
+
+    Expects a JSON payload:
+        - dag_id (str): Required. ID of the DAG to revert.
+
+    Returns:
+        Response 200: DAG reverted to previous version, lists deleted version.
+        Response 400: No suitable previous version found.
+        Response 404: DAG or versions not found.
+        Response 500: Internal error during revert.
+    """
+    return _revert_dag_schedule_override(delete_all=False)
+
+@csrf.exempt
+@dagen_rest_bp.route("/dags/schedule/revert/all", methods=["POST"])
+@require_api_key
+def revert_all_external_schedule_overrides():
+    """
+    Revert top DAG versions created by the external scheduler for a given DAG.
+    This reverts all the latest DAG versions created by the external scheduler
+    until a version created by a non-external user is encountered.
+
+    Expects a JSON payload:
+        - dag_id (str): Required. ID of the DAG to revert.
+
+    Returns:
+        Response 200: DAG reverted to latest non-external version, lists all deleted versions.
+        Response 400: No non-external versions available to revert to.
+        Response 404: DAG or versions not found.
+        Response 500: Internal error during revert.
+    """
+    return _revert_dag_schedule_override(delete_all=True)
+
+def _revert_dag_schedule_override(delete_all: bool):
+    try:
+        data = request.get_json(force=True)
+        dag_id = data.get("dag_id")
+
+        if not dag_id:
+            return jsonify({"error": "Missing 'dag_id' in request body"}), 400
+
+        with create_session() as session:
+            dag_obj = session.query(DagenDag).filter(DagenDag.dag_id == dag_id).first()
+            if not dag_obj:
+                return jsonify({"error": f"DAG '{dag_id}' not found"}), 404
+
+            versions = (
+                session.query(DagenDagVersion)
+                .filter(DagenDagVersion.dag_id == dag_id)
+                .order_by(DagenDagVersion.version.desc())
+                .all()
+            )
+
+            if not versions:
+                return jsonify({"error": f"No versions found for DAG '{dag_id}'"}), 404
+
+            new_live_version = None
+            deleted_versions = []
+
+            for version in versions:
+                if version.creator_id == EXTERNAL_SCHEDULER_USER_ID:
+                    if delete_all or len(deleted_versions) == 0:
+                        deleted_versions.append(version.version)
+                        session.delete(version)
+                    else:
+                        new_live_version = version.version
+                        break
+                else:
+                    new_live_version = version.version
+                    break
+
+            if new_live_version is None or new_live_version < 1:
+                return jsonify({
+                    "error": f"No non-external versions found for DAG '{dag_id}'. Nothing to revert to."
+                }), 400
+
+            dag_obj._live_version = new_live_version
+            dag_obj.updated_at = datetime.now(timezone.utc)
+            session.commit()
+
+        refresh_dagbag(dag_id=dag_id)
+
+        return jsonify({
+            "message": f"Reverted DAG '{dag_id}' to version {new_live_version}",
+            "deleted_versions": deleted_versions
+        }), 200
+
+    except Exception as e:
+        log.exception("Failed to revert DAG schedule override")
         return jsonify({"error": str(e)}), 500


### PR DESCRIPTION
This PR introduces a set of new functionalities to enable custom DAG triggering and schedule updates via APIs protected using X-API-Key header

**New endpoints**

1. POST /dags/run: Trigger a DAG run with custom execution datetime and optional conf.
2. PATCH /dags/schedule/update: Create a new DAG version with a given cron schedule.
3. POST /dags/schedule/revert/latest: Revert the most recent version created by the external scheduler.
4. POST /dags/schedule/revert/all: Revert all top DAG versions created by the external scheduler until a non-external version is found.
