### PR TITLE
[SECURITY] PolinRider followup: clean .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,5 +129,3 @@ dmypy.json
 .history
 
 # End of https://www.gitignore.io/api/linux,python,visualstudiocode
-temp_auto_push.bat
-temp_interactive_push.bat


### PR DESCRIPTION
## Follow-up cleanup

PolinRider also appended these lines to `.gitignore`:

- `temp_auto_push.bat` — malware history-rewrite propagation script
- `temp_interactive_push.bat` — variant of the same
- `.gitignore` (where present, adjacent to the above) — added so further .gitignore mutations are hidden

This PR removes those lines only. No other content changed.

## Refs

- OSM dossier: https://opensourcemalware.com/blog/polinrider-attack
